### PR TITLE
Make queue_and_wait_images async, fixes #2

### DIFF
--- a/comfy_api_simplified/comfy_api_wrapper.py
+++ b/comfy_api_simplified/comfy_api_wrapper.py
@@ -108,8 +108,8 @@ class ComfyApiWrapper:
                         if data["node"] is None and data["prompt_id"] == prompt_id:
                             return prompt_id
 
-    def queue_and_wait_images(
-        self, prompt: ComfyWorkflowWrapper, output_node_title: str, loop:asyncio.BaseEventLoop = asyncio.get_event_loop()
+    async def queue_and_wait_images(
+        self, prompt: ComfyWorkflowWrapper, output_node_title: str
     ) -> dict:
         """
         Queues a prompt with a ComfyWorkflowWrapper object and waits for the images to be generated.
@@ -125,7 +125,7 @@ class ComfyApiWrapper:
             Exception: If the request fails with a non-200 status code.
         """
 
-        prompt_id = loop.run_until_complete(self.queue_prompt_and_wait(prompt))
+        prompt_id = await self.queue_prompt_and_wait(prompt)
         history = self.get_history(prompt_id)
         image_node_id = prompt.get_node_id(output_node_title)
         images = history[prompt_id]["outputs"][image_node_id]["images"]


### PR DESCRIPTION
Hey, this part was blocking execution of other code as it blocked the main event loop while waiting for the image. To get around this I made the function async, which and removed the `run_until_complete`. This should also fix #2, and get rid of the need for the `nest_asyncio.apply()`workaround.
If there was a reason why this was relying on `run_until_complete` instead of just making the function async and awaiting it let me know.