### PR TITLE
Improve compatibility for workflows with non-ASCII characters by using UTF-8 encoding

### DIFF
--- a/comfy_api_simplified/comfy_workflow_wrapper.py
+++ b/comfy_api_simplified/comfy_workflow_wrapper.py
@@ -12,7 +12,7 @@ class ComfyWorkflowWrapper(dict):
         Args:
             path (str): The path to the workflow file.
         """
-        with open(path) as f:
+        with open(path, 'r', encoding='utf-8') as f:
             workflow_str = f.read()
         super().__init__(json.loads(workflow_str))
 


### PR DESCRIPTION
### Problem
When loading workflow files containing Chinese or other non-ASCII characters, a `UnicodeDecodeError` is raised on systems where the default encoding is not UTF-8 (e.g., Windows). This happens because Python's `open()` function defaults to using the system's locale encoding (`gbk` on some Windows systems), which fails to decode UTF-8 content.

The specific error is:
`
    workflow_str = f.read()
                   ^^^^^^^^
UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 705: illegal multibyte sequence
`

### Solution
This PR addresses the issue by explicitly specifying `encoding='utf-8'` in all `open()` calls when reading workflow files. This ensures that workflows with non-ASCII characters (e.g., Chinese) are correctly loaded, regardless of the system's default encoding.

### Impact
This change improves compatibility for workflows containing non-ASCII characters (e.g., Chinese) by ensuring all workflow files are read using UTF-8 encoding. This guarantees proper behavior across different platforms and default encoding configurations.

### Test
- Verified that workflows load successfully without triggering `UnicodeDecodeError`.
- No regressions observed in workflows without non-ASCII characters.
