### PR TITLE
Support to download videos with VideoCombine from ComfyUI-VideoHelper…

### DIFF
--- a/comfy_api_simplified/comfy_api_wrapper.py
+++ b/comfy_api_simplified/comfy_api_wrapper.py
@@ -128,7 +128,17 @@ class ComfyApiWrapper:
         prompt_id = loop.run_until_complete(self.queue_prompt_and_wait(prompt))
         history = self.get_history(prompt_id)
         image_node_id = prompt.get_node_id(output_node_title)
-        images = history[prompt_id]["outputs"][image_node_id]["images"]
+        result_node = history[prompt_id]["outputs"][image_node_id]
+
+        def custom_node_result():
+            match result_node:
+                case {"images": images}:
+                    return images
+                case {"gifs": gifs}:
+                    return gifs
+
+        images = custom_node_result()
+
         return {
             image["filename"]: self.get_image(
                 image["filename"], image["subfolder"], image["type"]


### PR DESCRIPTION
I was using this amazing piece of software to upload some files and the generate a video.

I realize that current `get_image` and `upload_image` works pretty well if your using any kind of file (audio or video), but i also need to download a video. 

Current `queue_and_wait_images` is attached to `Save Image` node return structure from comfy-core.

With this change i am proposing here now you can use `Video Combine` node from `ComfyUI-VideoHelperSuite` to download a video. This node is usually used. And also prepared the code for any other new return structure support in the future.

Hope you like it!

